### PR TITLE
Using importHelpers and tslib to emit smaller js bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Using `importHelpers` and `tslib` to emit smaller bundles from Typescript ([#1](https://github.com/brisberg/typescript-toolchain/pull/1))
+
 ### Changed
 - Moved repository from @brisberg/typescript-pkg to @brisberg/typescript-toolchain
+
 
 ## [2.0.2] - 2020-06-23
 
 ### Changed
 - Correctly exporting typings .d.ts files for package consumers
+
 
 ## [2.0.1] - 2020-06-23
 
@@ -44,10 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESLint will no longer lint built files
 - Packages will be pushed to registry.npmjs.org instead of GPR.
 
+
 ## [1.0.1] - 2020-06-23
 
 ### Changed
 - Upgrade Jest to latest (v26)
+
 
 ## [1.0.0] - 2020-06-23
 ### Added

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "test": "jest",
     "lint": "eslint \"src/**/*.ts\""
   },
+  "dependencies": {
+    "tslib": "^2.0.0"
+  },
   "devDependencies": {
     "@types/jest": "^26.0.3",
     "@typescript-eslint/eslint-plugin": "^3.5.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "esModuleInterop": true,
     "experimentalDecorators": false,
     "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
     "noImplicitReturns": true
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,6 +3758,11 @@ tslib@^1.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
+tslib@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+
 tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"


### PR DESCRIPTION
We can use `tslib` to avoid duplicating emitted import helper functions in every file. Ends up reducing the final bundle by removing duplications. Requires `tslib` as a runtime dep.

Requires the `importHelpers` TypeScript compiler option.

Explanation:
https://spblog.net/post/2018/10/26/TypeScript-Tips-How-to-reduce-the-size-of-a-bundle

Real world usage:
https://angular.io/guide/migration-update-libraries-tslib

